### PR TITLE
protobuf-cpp and protobuf-python have potential CVE-2022-1941

### DIFF
--- a/tools/provisioning/python/requirements.txt
+++ b/tools/provisioning/python/requirements.txt
@@ -24,7 +24,7 @@ packaging==21.2
 pandas==1.3.4
 pandoc-include==0.8.4
 pluggy==1.0.0
-protobuf==3.19.1
+protobuf==3.19.5
 py==1.11.0
 pyarrow==6.0.0
 pycodestyle==2.8.0


### PR DESCRIPTION
## Describe the bugs: 🐛
A message parsing and memory management vulnerability in ProtocolBuffer’s C++ and Python implementations can trigger an out of memory (OOM) failure when processing a specially crafted message, which could lead to a denial of service (DoS) on services using the libraries.

**CVE-2022-1941**
`CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H`
GHSA-8gq9-2x98-w8hf
